### PR TITLE
modified:   ExcelCommons install.sql plsql/ExcelGen.pkb plsql/ExcelGe…

### DIFF
--- a/install.sql
+++ b/install.sql
@@ -1,8 +1,8 @@
 alter session set plsql_optimize_level=3;
 
 prompt Creating package XUTL_CDF ...
-@@MSUtilities/CDFReader/xutl_cdf.pks
-@@MSUtilities/CDFReader/xutl_cdf.pkb
+@@MSUtilities/CDFManager/xutl_cdf.pks
+@@MSUtilities/CDFManager/xutl_cdf.pkb
 
 prompt Creating package XUTL_OFFCRYPTO ...
 @@MSUtilities/OfficeCrypto/xutl_offcrypto.pks

--- a/plsql/ExcelGen.pks
+++ b/plsql/ExcelGen.pks
@@ -32,6 +32,7 @@ create or replace package ExcelGen is
     Marc Bleron       2021-04-29     Added optional parameter p_sheetIndex in 
                                      addSheetFromXXX routines
     Marc Bleron       2021-05-13     Added XLSB support
+    Lee Lindley       2021-07-25     Added setNumFormat
 ====================================================================================== */
 
   -- file types
@@ -288,6 +289,11 @@ create or replace package ExcelGen is
   );
 
   procedure setDateFormat (
+    p_ctxId   in ctxHandle
+  , p_format  in varchar2
+  );
+
+  procedure setNumFormat (
     p_ctxId   in ctxHandle
   , p_format  in varchar2
   );


### PR DESCRIPTION
…n.pks

Add setNumFormat public procedure and associated functionality in the package
body. Operates the same way setDateFormat does. Not ideal in that it is for all
number columns and would prefer to specify it on a per column basis, but
that is beyond my kin and appears as if would take considerable redesign. This
works well enough for the most common use cases.

install.sql had a directory name change out from under it in one of the
recursive submodules.